### PR TITLE
Don't require `Unconstrined1`

### DIFF
--- a/Data/Row/Internal.hs
+++ b/Data/Row/Internal.hs
@@ -22,7 +22,7 @@ module Data.Row.Internal
   , type (.\), type (.!), type (.-), type (.+), type (.\\), type (.==)
   , Lacks, HasType
   -- * Row Classes
-  , Labels, labels
+  , Labels, labels, labels'
   , Forall(..), Forall2(..)
   , Unconstrained1
   -- * Helper functions
@@ -35,6 +35,8 @@ module Data.Row.Internal
   , uniqueMap
   , IsA(..)
   , As(..)
+
+  , FoldStep
   )
 where
 
@@ -315,6 +317,9 @@ labels :: forall ρ c s. (IsString s, Forall ρ c) => [s]
 labels = getConst $ metamorph @ρ @c @(Const ()) @(Const [s]) @(Const ()) Proxy (const $ Const []) doUncons doCons (Const ())
   where doUncons _ _ = (Const (), Const ())
         doCons l _ (Const c) = Const $ show' l : c
+
+labels' :: forall ρ s. (IsString s, Forall ρ Unconstrained1) => [s]
+labels' = labels @ρ @Unconstrained1
 
 
 {--------------------------------------------------------------------

--- a/Data/Row/Records.hs
+++ b/Data/Row/Records.hs
@@ -294,17 +294,17 @@ transform' :: forall r f g. Forall r Unconstrained1 => (forall a. f a -> g a) ->
 transform' = transform @Unconstrained1 @r
 
 -- | Applicative sequencing over a record
-sequence :: forall f r c. (Forall r c, Applicative f)
-         => Rec (Map f r) -> f (Rec r)
-sequence = getCompose . metamorph @r @c @(RMap f) @(Compose f Rec) @f Proxy doNil doUncons doCons . RMap
+sequence' :: forall f r c. (Forall r c, Applicative f)
+          => Rec (Map f r) -> f (Rec r)
+sequence' = getCompose . metamorph @r @c @(RMap f) @(Compose f Rec) @f Proxy doNil doUncons doCons . RMap
   where
     doNil _ = Compose (pure empty)
     doUncons l (RMap r) = (r .! l, RMap $ unsafeRemove l r)
     doCons l fv (Compose fr) = Compose $ unsafeInjectFront l <$> fv <*> fr
 
-sequence' :: forall f r. (Forall r Unconstrained1, Applicative f)
-          => Rec (Map f r) -> f (Rec r)
-sequence' = sequence @_ @_ @Unconstrained1
+sequence :: forall f r. (Forall r Unconstrained1, Applicative f)
+         => Rec (Map f r) -> f (Rec r)
+sequence = sequence' @_ @_ @Unconstrained1
 
 -- $compose
 -- We can easily convert between mapping two functors over the types of a row
@@ -317,32 +317,32 @@ sequence' = sequence @_ @_ @Unconstrained1
 
 -- | Convert from a record where two functors have been mapped over the types to
 -- one where the composition of the two functors is mapped over the types.
-compose :: forall c (f :: * -> *) g r . Forall r c
+compose' :: forall c (f :: * -> *) g r . Forall r c
         => Rec (Map f (Map g r)) -> Rec (Map (Compose f g) r)
-compose = unRMap . metamorph @r @c @(RMap2 f g) @(RMap (Compose f g)) @(Compose f g) Proxy doNil doUncons doCons . RMap2
+compose' = unRMap . metamorph @r @c @(RMap2 f g) @(RMap (Compose f g)) @(Compose f g) Proxy doNil doUncons doCons . RMap2
   where
     doNil _ = RMap empty
     doUncons l (RMap2 r) = (Compose $ r .! l, RMap2 $ unsafeRemove l r)
     doCons l v (RMap r) = RMap $ unsafeInjectFront l v r
 
-compose' :: forall (f :: * -> *) g r . Forall r Unconstrained1
-         => Rec (Map f (Map g r)) -> Rec (Map (Compose f g) r)
-compose' = compose @Unconstrained1 @f @g @r
+compose :: forall (f :: * -> *) g r . Forall r Unconstrained1
+        => Rec (Map f (Map g r)) -> Rec (Map (Compose f g) r)
+compose = compose' @Unconstrained1 @f @g @r
 
 -- | Convert from a record where the composition of two functors have been mapped
 -- over the types to one where the two functors are mapped individually one at a
 -- time over the types.
-uncompose :: forall c (f :: * -> *) g r . Forall r c
-          => Rec (Map (Compose f g) r) -> Rec (Map f (Map g r))
-uncompose = unRMap2 . metamorph @r @c @(RMap (Compose f g)) @(RMap2 f g) @(Compose f g) Proxy doNil doUncons doCons . RMap
+uncompose' :: forall c (f :: * -> *) g r . Forall r c
+           => Rec (Map (Compose f g) r) -> Rec (Map f (Map g r))
+uncompose' = unRMap2 . metamorph @r @c @(RMap (Compose f g)) @(RMap2 f g) @(Compose f g) Proxy doNil doUncons doCons . RMap
   where
     doNil _ = RMap2 empty
     doUncons l (RMap r) = (r .! l, RMap $ unsafeRemove l r)
     doCons l (Compose v) (RMap2 r) = RMap2 $ unsafeInjectFront l v r
 
-uncompose' :: forall (f :: * -> *) g r . Forall r Unconstrained1
+uncompose :: forall (f :: * -> *) g r . Forall r Unconstrained1
           => Rec (Map (Compose f g) r) -> Rec (Map f (Map g r))
-uncompose' = uncompose @Unconstrained1 @f @g @r
+uncompose = uncompose' @Unconstrained1 @f @g @r
 
 
 -- | RZipPair is used internally as a type level lambda for zipping records.


### PR DESCRIPTION
This PR includes versions of `compose`, `uncompose`, `sequence`, and `labels` that don't require `Unconstrained1`. This avoids you from having to include multiple `Forall` constraints when one of them is `Unconstrained1`.

For consistency, I personally think that the `'`s should be on the more specific ones, but this breaks compatibility.