### PR TITLE
Remove FoldStep and change Forall2 to Biforall

### DIFF
--- a/Data/Row/Internal.hs
+++ b/Data/Row/Internal.hs
@@ -31,7 +31,7 @@ module Data.Row.Internal
   , show'
   , toKey
   , type (≈)
-  , WellBehaved, AllUniqueLabels, DotProduct, Zip, Map, Subset, Disjoint
+  , WellBehaved, AllUniqueLabels, Ap, Zip, Map, Subset, Disjoint
 
   , mapForall
   , freeForall
@@ -391,13 +391,13 @@ type family MapR (f :: a -> b) (r :: [LT a]) :: [LT b] where
 
 -- | Take two rows with the same labels, and apply the type operator from the
 -- first row to the type of the second.
-type family DotProduct (fs :: Row (* -> *)) (r :: Row *) :: Row * where
-  DotProduct (R fs) (R r) = R (DotProductR fs r)
+type family Ap (fs :: Row (* -> *)) (r :: Row *) :: Row * where
+  Ap (R fs) (R r) = R (ApR fs r)
 
-type family DotProductR (fs :: [LT (* -> *)]) (r :: [LT *]) :: [LT *] where
-  DotProductR '[] '[] = '[]
-  DotProductR (l :-> f ': tf) (l :-> v ': tv) = l :-> f v ': DotProductR tf tv
-  DotProductR _ _ = TypeError (TL.Text "Row types with different label sets cannot be Dot Producted")
+type family ApR (fs :: [LT (* -> *)]) (r :: [LT *]) :: [LT *] where
+  ApR '[] '[] = '[]
+  ApR (l :-> f ': tf) (l :-> v ': tv) = l :-> f v ': ApR tf tv
+  ApR _ _ = TypeError (TL.Text "Row types with different label sets cannot be App'd together.")
 
 -- | Zips two rows together to create a Row of the pairs.
 --   The two rows must have the same set of labels.

--- a/Data/Row/Internal.hs
+++ b/Data/Row/Internal.hs
@@ -421,10 +421,10 @@ type family MapR (f :: a -> b) (r :: [LT a]) :: [LT b] where
 
 -- | Take two rows with the same labels, and apply the type operator from the
 -- first row to the type of the second.
-type family Ap (fs :: Row (* -> *)) (r :: Row *) :: Row * where
+type family Ap (fs :: Row (a -> b)) (r :: Row a) :: Row b where
   Ap (R fs) (R r) = R (ApR fs r)
 
-type family ApR (fs :: [LT (* -> *)]) (r :: [LT *]) :: [LT *] where
+type family ApR (fs :: [LT (a -> b)]) (r :: [LT a]) :: [LT b] where
   ApR '[] '[] = '[]
   ApR (l :-> f ': tf) (l :-> v ': tv) = l :-> f v ': ApR tf tv
   ApR _ _ = TypeError (TL.Text "Row types with different label sets cannot be App'd together.")

--- a/Data/Row/Records.hs
+++ b/Data/Row/Records.hs
@@ -291,19 +291,19 @@ map f = unRMap . metamorph @_ @r @c @Rec @(RMap f) @Identity Proxy doNil doUncon
            => Label ℓ -> Identity τ -> RMap f ('R ρ) -> RMap f ('R (ℓ :-> τ ': ρ))
     doCons l (Identity v) (RMap r) = RMap (unsafeInjectFront l (f v) r)
 
-newtype RFMap (g :: * -> *) (ϕ :: Row (* -> *)) (ρ :: Row *) = RFMap { unRFMap :: Rec (DotProduct ϕ (Map g ρ)) }
-newtype DotProd (ϕ :: Row (* -> *)) (ρ :: Row *) = DotProd (Rec (DotProduct ϕ ρ))
+newtype RFMap (g :: * -> *) (ϕ :: Row (* -> *)) (ρ :: Row *) = RFMap { unRFMap :: Rec (Ap ϕ (Map g ρ)) }
+newtype RecAp (ϕ :: Row (* -> *)) (ρ :: Row *) = RecAp (Rec (Ap ϕ ρ))
 newtype App (f :: * -> *) (a :: *) = App (f a)
 
--- | A function to map over a DotProduct record given constraints.
+-- | A function to map over a Ap record given constraints.
 mapF :: forall c1 c2 g ϕ ρ. BiForall ϕ ρ c1 c2
      => (forall f a. (c1 f, c2 a) => f a -> f (g a))
-     -> Rec (DotProduct ϕ ρ)
-     -> Rec (DotProduct ϕ (Map g ρ))
-mapF f = unRFMap . biMetamorph @_ @_ @ϕ @ρ @c1 @c2 @DotProd @(RFMap g) @App Proxy doNil doUncons doCons . DotProd
+     -> Rec (Ap ϕ ρ)
+     -> Rec (Ap ϕ (Map g ρ))
+mapF f = unRFMap . biMetamorph @_ @_ @ϕ @ρ @c1 @c2 @RecAp @(RFMap g) @App Proxy doNil doUncons doCons . RecAp
   where
     doNil _ = RFMap empty
-    doUncons l (DotProd r) = (App $ r .! l, DotProd $ unsafeRemove l r)
+    doUncons l (RecAp r) = (App $ r .! l, RecAp $ unsafeRemove l r)
     doCons :: forall ℓ τ1 τ2 ρ1 ρ2. (KnownSymbol ℓ, c1 τ1, c2 τ2)
            => Label ℓ -> App τ1 τ2 -> RFMap g ('R ρ1) ('R ρ2) -> RFMap g ('R (ℓ :-> τ1 ': ρ1)) ('R (ℓ :-> τ2 ': ρ2))
     doCons l (App v) (RFMap r) = RFMap (unsafeInjectFront l (f @τ1 @τ2 v) r)

--- a/Data/Row/Records.hs
+++ b/Data/Row/Records.hs
@@ -296,15 +296,15 @@ newtype RecAp (ϕ :: Row (* -> *)) (ρ :: Row *) = RecAp (Rec (Ap ϕ ρ))
 newtype App (f :: * -> *) (a :: *) = App (f a)
 
 -- | A function to map over a Ap record given constraints.
-mapF :: forall c1 c2 g ϕ ρ. BiForall ϕ ρ c1 c2
-     => (forall f a. (c1 f, c2 a) => f a -> f (g a))
+mapF :: forall c g ϕ ρ. BiForall ϕ ρ c
+     => (forall f a. (c f a) => f a -> f (g a))
      -> Rec (Ap ϕ ρ)
      -> Rec (Ap ϕ (Map g ρ))
-mapF f = unRFMap . biMetamorph @_ @_ @ϕ @ρ @c1 @c2 @RecAp @(RFMap g) @App Proxy doNil doUncons doCons . RecAp
+mapF f = unRFMap . biMetamorph @_ @_ @ϕ @ρ @c @RecAp @(RFMap g) @App Proxy doNil doUncons doCons . RecAp
   where
     doNil _ = RFMap empty
     doUncons l (RecAp r) = (App $ r .! l, RecAp $ unsafeRemove l r)
-    doCons :: forall ℓ τ1 τ2 ρ1 ρ2. (KnownSymbol ℓ, c1 τ1, c2 τ2)
+    doCons :: forall ℓ τ1 τ2 ρ1 ρ2. (KnownSymbol ℓ, c τ1 τ2)
            => Label ℓ -> App τ1 τ2 -> RFMap g ('R ρ1) ('R ρ2) -> RFMap g ('R (ℓ :-> τ1 ': ρ1)) ('R (ℓ :-> τ2 ': ρ2))
     doCons l (App v) (RFMap r) = RFMap (unsafeInjectFront l (f @τ1 @τ2 v) r)
 
@@ -389,8 +389,8 @@ newtype RecPair  (ρ1 :: Row *) (ρ2 :: Row *) = RecPair  (Rec ρ1, Rec ρ2)
 newtype RZipPair (ρ1 :: Row *) (ρ2 :: Row *) = RZipPair { unRZipPair :: Rec (Zip ρ1 ρ2) }
 
 -- | Zips together two records that have the same set of labels.
-zip :: forall r1 r2. BiForall r1 r2 Unconstrained1 Unconstrained1 => Rec r1 -> Rec r2 -> Rec (Zip r1 r2)
-zip r1 r2 = unRZipPair $ biMetamorph @_ @_ @r1 @r2 @Unconstrained1 @Unconstrained1 @RecPair @RZipPair @(,) Proxy doNil doUncons doCons $ RecPair (r1, r2)
+zip :: forall r1 r2. BiForall r1 r2 Unconstrained2 => Rec r1 -> Rec r2 -> Rec (Zip r1 r2)
+zip r1 r2 = unRZipPair $ biMetamorph @_ @_ @r1 @r2 @Unconstrained2 @RecPair @RZipPair @(,) Proxy doNil doUncons doCons $ RecPair (r1, r2)
   where
     doNil _ = RZipPair empty
     doUncons l (RecPair (r1, r2)) = ((r1 .! l, r2 .! l), RecPair (unsafeRemove l r1, unsafeRemove l r2))

--- a/Data/Row/Records.hs
+++ b/Data/Row/Records.hs
@@ -291,12 +291,12 @@ map f = unRMap . metamorph @_ @r @c @Rec @(RMap f) @Identity Proxy doNil doUncon
            => Label ℓ -> Identity τ -> RMap f ('R ρ) -> RMap f ('R (ℓ :-> τ ': ρ))
     doCons l (Identity v) (RMap r) = RMap (unsafeInjectFront l (f v) r)
 
-newtype RFMap (g :: * -> *) (ϕ :: Row (* -> *)) (ρ :: Row *) = RFMap { unRFMap :: Rec (Ap ϕ (Map g ρ)) }
-newtype RecAp (ϕ :: Row (* -> *)) (ρ :: Row *) = RecAp (Rec (Ap ϕ ρ))
-newtype App (f :: * -> *) (a :: *) = App (f a)
+newtype RFMap (g :: k1 -> k2) (ϕ :: Row (k2 -> *)) (ρ :: Row k1) = RFMap { unRFMap :: Rec (Ap ϕ (Map g ρ)) }
+newtype RecAp (ϕ :: Row (k -> *)) (ρ :: Row k) = RecAp (Rec (Ap ϕ ρ))
+newtype App (f :: k -> *) (a :: k) = App (f a)
 
 -- | A function to map over a Ap record given constraints.
-mapF :: forall c g ϕ ρ. BiForall ϕ ρ c
+mapF :: forall c g (ϕ :: Row (k -> *)) (ρ :: Row k). BiForall ϕ ρ c
      => (forall f a. (c f a) => f a -> f (g a))
      -> Rec (Ap ϕ ρ)
      -> Rec (Ap ϕ (Map g ρ))


### PR DESCRIPTION
I'm not sure what kind of problems removing `FoldStep` might have, but I don't think it's very useful.  For performance reasons, anyone writing their own `metamorph` functions will want to use the unsafe inject functions, and so `FoldStep` is not necessary.  Additionally, `FoldStep` is not always strong enough, meaning that the unsafe functions are the only possibility even if the `FoldStep` constraint is there.  In an ideal world, there would be a quick and easy constraint that is both simpler and more powerful than `FoldStep`, but I don't know what that is.

`Forall2` was a bit of a hack that I put together to support zipping two records together.  After seeing Issue https://github.com/target/row-types/issues/31, I was inspired to rewrite `Forall2` to make it more broadly useful: this led to `BiForall`.  Not only is it simpler than the old `Forall2`, but it simplifies the record zipping function too.  Additionally, it can be used to do `fmap`-like operations over records (see the `mapF` function).  I see it as a strict improvement over `Forall2`.