### PR TITLE
Add Dynamic HashMap compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # Build/sandbox files
 dist
+dist-newstyle
 cabal-dev
 .cabal-sandbox/
 cabal.sandbox.config

--- a/Data/Row/Records.hs
+++ b/Data/Row/Records.hs
@@ -41,6 +41,8 @@ module Data.Row.Records
   -- * Native Conversion
   -- $native
   , toNative, fromNative
+  -- * Dynamic Conversion
+  , toDynamicMap, fromDynamicMap
   -- * Row operations
   -- ** Map
   , Map, map, map'
@@ -67,6 +69,7 @@ import Prelude hiding (map, sequence, zip)
 import Control.DeepSeq (NFData(..), deepseq)
 
 import Data.Constraint ((\\))
+import Data.Dynamic
 import Data.Functor.Compose
 import Data.Functor.Const
 import Data.Functor.Identity
@@ -421,6 +424,26 @@ fromLabelsMapA f = fromLabelsA @(IsA c g) @f @(Map g ρ) inner
                 \\ uniqueMap @g @ρ
    where inner :: forall l a. (KnownSymbol l, IsA c g a) => Label l -> f a
          inner l = case as @c @g @a of As -> f l
+
+
+{--------------------------------------------------------------------
+  Dynamic compatibility
+--------------------------------------------------------------------}
+
+-- | Converts a 'Rec' into a 'HashMap' of 'Dynamic's.
+toDynamicMap :: Forall r Typeable => Rec r -> HashMap Text Dynamic
+toDynamicMap = eraseToHashMap @Typeable @_ @Text @Dynamic toDyn
+
+-- | Produces a 'Rec' from a 'HashMap' of 'Dynamic's.
+fromDynamicMap :: (AllUniqueLabels r, Forall r Typeable)
+               => HashMap Text Dynamic -> Rec r
+fromDynamicMap m = fromLabels @Typeable
+  $ \ (toKey -> k) -> unMaybe k (M.lookup k m >>= fromDynamic)
+  where unMaybe :: Text -> Maybe a -> a
+        unMaybe _ (Just x) = x
+        unMaybe k Nothing  = error $ "Key " ++ show k
+          ++ " does not exist in the Map or has the wrong type."
+
 
 {--------------------------------------------------------------------
   Native data type compatibility

--- a/Data/Row/Records.hs
+++ b/Data/Row/Records.hs
@@ -436,13 +436,9 @@ toDynamicMap = eraseToHashMap @Typeable @_ @Text @Dynamic toDyn
 
 -- | Produces a 'Rec' from a 'HashMap' of 'Dynamic's.
 fromDynamicMap :: (AllUniqueLabels r, Forall r Typeable)
-               => HashMap Text Dynamic -> Rec r
-fromDynamicMap m = fromLabels @Typeable
-  $ \ (toKey -> k) -> unMaybe k (M.lookup k m >>= fromDynamic)
-  where unMaybe :: Text -> Maybe a -> a
-        unMaybe _ (Just x) = x
-        unMaybe k Nothing  = error $ "Key " ++ show k
-          ++ " does not exist in the Map or has the wrong type."
+               => HashMap Text Dynamic -> Maybe (Rec r)
+fromDynamicMap m = fromLabelsA @Typeable
+  $ \ (toKey -> k) -> M.lookup k m >>= fromDynamic
 
 
 {--------------------------------------------------------------------


### PR DESCRIPTION
This PR adds the functions `toDynamicMap` and `fromDynamicMap` in `Data.Row.Record`.  These functions allow one to convert a `Rec` to and from the less typed `HashMap Text Dynamic`.