### PR TITLE
Add generic-lens compatibility

### DIFF
--- a/Data/Row/Records.hs
+++ b/Data/Row/Records.hs
@@ -68,23 +68,24 @@ import Prelude hiding (map, sequence, zip)
 
 import Control.DeepSeq (NFData(..), deepseq)
 
-import Data.Constraint ((\\))
-import Data.Dynamic
-import Data.Functor.Compose
-import Data.Functor.Const
-import Data.Functor.Identity
-import Data.Functor.Product
-import Data.Hashable
-import Data.HashMap.Lazy (HashMap)
-import qualified Data.HashMap.Lazy as M
-import qualified Data.List as L
-import Data.Monoid (Endo(..), appEndo)
-import Data.Proxy
-import Data.String (IsString)
-import Data.Text (Text)
+import           Data.Constraint              ((\\))
+import           Data.Dynamic
+import           Data.Functor.Compose
+import           Data.Functor.Const
+import           Data.Functor.Identity
+import           Data.Functor.Product
+import           Data.Generics.Product.Fields (HasField(..), HasField'(..))
+import           Data.Hashable
+import           Data.HashMap.Lazy            (HashMap)
+import qualified Data.HashMap.Lazy            as M
+import qualified Data.List                    as L
+import           Data.Monoid                  (Endo(..), appEndo)
+import           Data.Proxy
+import           Data.String                  (IsString)
+import           Data.Text                    (Text)
 
 import qualified GHC.Generics as G
-import GHC.TypeLits
+import           GHC.TypeLits
 
 import Unsafe.Coerce
 
@@ -635,3 +636,27 @@ instance (FromNative l ρ₁, FromNative r ρ₂, ρ ≈ ρ₁ .+ ρ₂)
 -- | Convert a Haskell record to a row-types Rec.
 fromNative :: forall t ρ. (G.Generic t, FromNative (G.Rep t) ρ) => t -> Rec ρ
 fromNative = fromNative' . G.from
+
+
+{--------------------------------------------------------------------
+  Generic-lens compatibility
+--------------------------------------------------------------------}
+
+-- | Every field in a row-types based record has a 'HasField' instance.
+instance {-# OVERLAPPING #-}
+  ( KnownSymbol name
+  , r' .! name ≈ b
+  , r  .! name ≈ a
+  , r' ~ Modify name b r
+  , r  ~ Modify name a r')
+  => HasField name (Rec r) (Rec r') a b where
+  field = focus (Label @name)
+  {-# INLINE field #-}
+
+instance {-# OVERLAPPING #-}
+  ( KnownSymbol name
+  , r .! name ≈ a
+  , r ~ Modify name a r)
+  => HasField' name (Rec r) a where
+  field' = focus (Label @name)
+  {-# INLINE field' #-}

--- a/row-types.cabal
+++ b/row-types.cabal
@@ -30,6 +30,8 @@ Library
                  deepseq >= 1.4,
                  hashable >= 1.2,
                  unordered-containers >= 0.2,
+                 generic-lens >= 1.0.0.0,
+                 profunctors >= 5.0,
                  text
   Exposed-modules: Data.Row
                  , Data.Row.Internal
@@ -88,6 +90,7 @@ test-suite test
   ghc-options: -W
   other-modules: Examples
   build-depends: base >= 2 && < 6
+               , generic-lens >= 1.1.0.0
                , row-types
   Extensions: AllowAmbiguousTypes,
               DataKinds,


### PR DESCRIPTION
This PR adds instances for the generic-lens classes `HasField` and `AsContructor` for records and  variants respectively.  Now, if one imports `Data.Generic.Labels` from generic-lens, then viewing and updating records and variants can be done in a lensy way.

I've updated the examples file to reflect these changes.

Note also that this required a minor generalization of the Variant `focus` function to work -- it should be entirely backwards compatible (up to type inference, which I think should be fine too).