### PR TITLE
Metamorph update

### DIFF
--- a/Data/Row.hs
+++ b/Data/Row.hs
@@ -31,7 +31,8 @@ module Data.Row
   , Var, Rec, Row, Empty, type (≈)
   , HasType, Lacks, type (.\), type (.+)
   , type (.\/), type (.\\), type (.//)
-  , BiForall, Forall, Switch(..)
+  , BiForall, Forall
+  , switch, caseon
   -- * Record Construction
   , empty
   , type (.==), (.==), pattern (:==)

--- a/Data/Row.hs
+++ b/Data/Row.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeOperators #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Row

--- a/Data/Row/Dictionaries.hs
+++ b/Data/Row/Dictionaries.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Row.Dictionaries
+--
+-- This module exports various dictionaries that help the type-checker when
+-- dealing with row-types.
+--
+-----------------------------------------------------------------------------
+
+
+module Data.Row.Dictionaries
+  ( uniqueMap, uniqueAp, uniqueZip
+  , extendHas, mapHas, apHas
+  , mapExtendSwap, apExtendSwap, zipExtendSwap
+  , FreeForall
+  , FreeBiForall
+  , freeForall
+  , mapForall
+  , IsA(..)
+  , As(..)
+  -- * Re-exports
+  , Dict(..), (:-)(..), HasDict(..), (\\), withDict
+  )
+where
+
+import Data.Constraint
+import Data.Proxy
+import qualified Unsafe.Coerce as UNSAFE
+import GHC.TypeLits
+
+import Data.Row.Internal
+
+
+
+-- | This data type is used to for its ability to existentially bind a type
+-- variable.  Particularly, it says that for the type 'a', there exists a 't'
+-- such that 'a ~ f t' and 'c t' holds.
+data As c f a where
+  As :: forall c f a t. (a ~ f t, c t) => As c f a
+
+-- | A class to capture the idea of 'As' so that it can be partially applied in
+-- a context.
+class IsA c f a where
+  as :: As c f a
+
+instance c a => IsA c f (f a) where
+  as = As
+
+-- | An internal type used by the 'metamorph' in 'mapForall'.
+newtype MapForall c f (r :: Row k) = MapForall { unMapForall :: Dict (Forall (Map f r) (IsA c f)) }
+
+-- | This allows us to derive a `Forall (Map f r) ..` from a `Forall r ..`.
+mapForall :: forall f c ρ. Forall ρ c :- Forall (Map f ρ) (IsA c f)
+mapForall = Sub $ unMapForall $ metamorph @_ @ρ @c @FlipConst @Proxy @(MapForall c f) @Proxy Proxy empty uncons cons $ Proxy
+  where empty _ = MapForall Dict
+        uncons _ _ = FlipConst Proxy
+        cons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ, FrontExtends ℓ τ ρ, AllUniqueLabels (Extend ℓ τ ρ))
+             => Label ℓ -> FlipConst (Proxy τ) (MapForall c f ρ)
+             -> MapForall c f (Extend ℓ τ ρ)
+        cons _ (FlipConst (MapForall Dict)) = case frontExtendsDict @ℓ @τ @ρ of
+          FrontExtendsDict Dict -> MapForall Dict
+            \\ mapExtendSwap @ℓ @τ @ρ @f
+            \\ uniqueMap @(Extend ℓ τ ρ) @f
+
+-- | Allow any 'Forall` over a row-type, be usable for 'Unconstrained1'.
+freeForall :: forall r c. Forall r c :- Forall r Unconstrained1
+freeForall = Sub $ UNSAFE.unsafeCoerce @(Dict (Forall r c)) Dict
+
+type FreeForall r = Forall r Unconstrained1
+
+type FreeBiForall r1 r2 = BiForall r1 r2 Unconstrained2
+
+extendHas :: forall r l t. Dict (Extend l t r .! l ≈ t)
+extendHas = UNSAFE.unsafeCoerce $ Dict @Unconstrained
+
+-- | This allows us to derive `Map f r .! l ≈ f t` from `r .! l ≈ t`
+mapHas :: forall f r l t. (r .! l ≈ t) :- (Map f r .! l ≈ f t, Map f r .- l ≈ Map f (r .- l))
+mapHas = Sub $ UNSAFE.unsafeCoerce $ Dict @(r .! l ≈ t)
+
+-- | This allows us to derive `Ap ϕ ρ .! l ≈ f t` from `ϕ .! l ≈ f` and `ρ .! l ≈ t`
+apHas :: forall ϕ ρ l f t. (ϕ .! l ≈ f, ρ .! l ≈ t) :- (Ap ϕ ρ .! l ≈ f t, Ap ϕ ρ .- l ≈ Ap (ϕ .- l) (ρ .- l))
+apHas = Sub $ UNSAFE.unsafeCoerce $ Dict @(ϕ .! l ≈ f, ρ .! l ≈ t)
+
+-- | Proof that the 'Map' type family preserves labels and their ordering.
+mapExtendSwap :: forall ℓ τ r f. Dict (Extend ℓ (f τ) (Map f r) ≈ Map f (Extend ℓ τ r))
+mapExtendSwap = UNSAFE.unsafeCoerce $ Dict @Unconstrained
+
+-- | Proof that the 'Ap' type family preserves labels and their ordering.
+apExtendSwap :: forall k ℓ (τ :: k) r (f :: k -> *) fs. Dict (Extend ℓ (f τ) (Ap fs r) ≈ Ap (Extend ℓ f fs) (Extend ℓ τ r))
+apExtendSwap = UNSAFE.unsafeCoerce $ Dict @Unconstrained
+
+-- | Proof that the 'Ap' type family preserves labels and their ordering.
+zipExtendSwap :: forall ℓ τ1 r1 τ2 r2. Dict (Extend ℓ (τ1, τ2) (Zip r1 r2) ≈ Zip (Extend ℓ τ1 r1) (Extend ℓ τ2 r2))
+zipExtendSwap = UNSAFE.unsafeCoerce $ Dict @Unconstrained
+
+-- | Map preserves uniqueness of labels.
+uniqueMap :: forall r f. Dict (AllUniqueLabels (Map f r) ≈ AllUniqueLabels r)
+uniqueMap = UNSAFE.unsafeCoerce $ Dict @Unconstrained
+
+-- | Ap preserves uniqueness of labels.
+uniqueAp :: forall r fs. Dict (AllUniqueLabels (Ap fs r) ≈ AllUniqueLabels r)
+uniqueAp = UNSAFE.unsafeCoerce $ Dict @Unconstrained
+
+-- | Zip preserves uniqueness of labels.
+uniqueZip :: forall r1 r2. Dict (AllUniqueLabels (Zip r1 r2) ≈ (AllUniqueLabels r1, AllUniqueLabels r2))
+uniqueZip = UNSAFE.unsafeCoerce $ Dict @Unconstrained

--- a/Data/Row/Dictionaries.hs
+++ b/Data/Row/Dictionaries.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}

--- a/Data/Row/Internal.hs
+++ b/Data/Row/Internal.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}

--- a/Data/Row/Internal.hs
+++ b/Data/Row/Internal.hs
@@ -57,9 +57,9 @@ module Data.Row.Internal
   , freeForall
   , uniqueMap
   , mapHas
-  , mapPreservesLabels
-  , apPreservesLabels
-  , zipPreservesLabels
+  , mapExtendSwap
+  , apExtendSwap
+  , zipExtendSwap
   , IsA(..)
   , As(..)
   )
@@ -246,7 +246,7 @@ class Forall (r :: Row k) (c :: k -> Constraint) where
                -- ^ The way to transform the empty element
             -> (forall ℓ τ ρ. (KnownSymbol ℓ, c τ) => Label ℓ -> f ('R (ℓ :-> τ ': ρ)) -> p (h τ) (f ('R ρ)))
                -- ^ The unfold
-            -> (forall ℓ τ ρ. (KnownSymbol ℓ, c τ, FrontExtends ℓ τ ρ) => Label ℓ -> p (h τ) (g ('R ρ)) -> g (Extend ℓ τ ('R ρ)))
+            -> (forall ℓ τ ρ. (KnownSymbol ℓ, c τ, FrontExtends ℓ τ ρ) => Label ℓ -> p (h τ) (g ('R ρ)) -> g ('R (ℓ :-> τ ': ρ)))
                -- ^ The fold
             -> f r  -- ^ The input structure
             -> g r
@@ -358,7 +358,7 @@ mapForall = Sub $ unMapForall $ metamorph @_ @ρ @c @(,) @(Const ()) @(MapForall
         cons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ, FrontExtends ℓ τ ρ)
              => Label ℓ -> (Const () τ, MapForall c f ('R ρ))
              -> MapForall c f (Extend ℓ τ ('R ρ))
-        cons _ (_, MapForall Dict) = case mapPreservesLabels @ℓ @τ @('R ρ) @f of
+        cons _ (_, MapForall Dict) = case mapExtendSwap @ℓ @τ @('R ρ) @f of
           Dict -> MapForall Dict
 
 -- | Map preserves uniqueness of labels.
@@ -374,16 +374,16 @@ mapHas :: forall f r l t. (r .! l ≈ t) :- (Map f r .! l ≈ f t)
 mapHas = Sub $ UNSAFE.unsafeCoerce $ Dict @(r .! l ≈ t)
 
 -- | Proof that the 'Map' type family preserves labels and their ordering.
-mapPreservesLabels :: forall ℓ τ r f. Dict (Extend ℓ (f τ) (Map f r) ≈ Map f (Extend ℓ τ r))
-mapPreservesLabels = UNSAFE.unsafeCoerce $ Dict @Unconstrained
+mapExtendSwap :: forall ℓ τ r f. Dict (Extend ℓ (f τ) (Map f r) ≈ Map f (Extend ℓ τ r))
+mapExtendSwap = UNSAFE.unsafeCoerce $ Dict @Unconstrained
 
 -- | Proof that the 'Ap' type family preserves labels and their ordering.
-apPreservesLabels :: forall k ℓ (τ :: k) r (f :: k -> *) fs. Dict (Extend ℓ (f τ) (Ap fs r) ≈ Ap (Extend ℓ f fs) (Extend ℓ τ r))
-apPreservesLabels = UNSAFE.unsafeCoerce $ Dict @Unconstrained
+apExtendSwap :: forall k ℓ (τ :: k) r (f :: k -> *) fs. Dict (Extend ℓ (f τ) (Ap fs r) ≈ Ap (Extend ℓ f fs) (Extend ℓ τ r))
+apExtendSwap = UNSAFE.unsafeCoerce $ Dict @Unconstrained
 
 -- | Proof that the 'Ap' type family preserves labels and their ordering.
-zipPreservesLabels :: forall ℓ τ1 r1 τ2 r2. Dict (Extend ℓ (τ1, τ2) (Zip r1 r2) ≈ Zip (Extend ℓ τ1 r1) (Extend ℓ τ2 r2))
-zipPreservesLabels = UNSAFE.unsafeCoerce $ Dict @Unconstrained
+zipExtendSwap :: forall ℓ τ1 r1 τ2 r2. Dict (Extend ℓ (τ1, τ2) (Zip r1 r2) ≈ Zip (Extend ℓ τ1 r1) (Extend ℓ τ2 r2))
+zipExtendSwap = UNSAFE.unsafeCoerce $ Dict @Unconstrained
 
 {--------------------------------------------------------------------
   Convenient type families and classes

--- a/Data/Row/Internal.hs
+++ b/Data/Row/Internal.hs
@@ -1,4 +1,17 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 -----------------------------------------------------------------------------
 -- |

--- a/Data/Row/Records.hs
+++ b/Data/Row/Records.hs
@@ -88,7 +88,6 @@ import Prelude hiding (map, sequence, zip)
 import Control.DeepSeq (NFData(..), deepseq)
 
 import           Data.Coerce
-import           Data.Constraint              ((\\))
 import           Data.Dynamic
 import           Data.Functor.Compose
 import           Data.Functor.Const
@@ -109,6 +108,7 @@ import           GHC.TypeLits
 
 import Unsafe.Coerce
 
+import Data.Row.Dictionaries
 import Data.Row.Internal
 
 

--- a/Data/Row/Records.hs
+++ b/Data/Row/Records.hs
@@ -44,6 +44,7 @@ module Data.Row.Records
   , extend, Extend, Lacks, type (.\)
   -- ** Restriction
   , type (.-), (.-)
+  , lazyRemove
   , restrict, split
   -- ** Modification
   , update, focus, multifocus, Modify, rename, Rename
@@ -79,8 +80,6 @@ module Data.Row.Records
   , labels, labels'
   -- ** Coerce
   , coerceRec
-  -- ** UNSAFE operations
-  , lazyRemove, unsafeInjectFront
   )
 where
 
@@ -485,14 +484,6 @@ zip r1 r2 = unRZipPair $ biMetamorph @_ @_ @r1 @r2 @Unconstrained2 @(,) @RecPair
            => Label ℓ -> ((τ1, τ2), RZipPair ρ1 ρ2) -> RZipPair (Extend ℓ τ1 ρ1) (Extend ℓ τ2 ρ2)
     doCons l ((v1, v2), RZipPair r) = RZipPair $ extend l (v1, v2) r
       \\ zipExtendSwap @ℓ @τ1 @ρ1 @τ2 @ρ2
-
--- | A helper function for unsafely adding an element to the front of a record.
--- This can cause the resulting record to be malformed, for instance, if the record
--- already contains labels that are lexicographically before the given label.
-unsafeInjectFront :: KnownSymbol l => Label l -> a -> Rec (R r) -> Rec (R (l :-> a ': r))
-unsafeInjectFront (toKey -> a) b (OR m) = OR $ M.insert a (HideType b) m
-{-# INLINE unsafeInjectFront #-}
-
 
 {--------------------------------------------------------------------
   Record initialization

--- a/Data/Row/Records.hs
+++ b/Data/Row/Records.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE PolyKinds #-}

--- a/Data/Row/Records.hs
+++ b/Data/Row/Records.hs
@@ -1,3 +1,17 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE UndecidableInstances #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Row.Records
@@ -419,6 +433,7 @@ uncompose = uncompose' @Unconstrained1 @f @g @r
 --
 -- Internally, this is implemented just with `unsafeCoerce`, but we provide the
 -- following implementation as a proof:
+--
 -- > newtype ConstR a b = ConstR (Rec a)
 -- > newtype FlipConstR a b = FlipConstR { unFlipConstR :: Rec b }
 -- > coerceRec = unFlipConstR . biMetamorph @_ @_ @r1 @r2 @Coercible @ConstR @FlipConstR @Const Proxy doNil doUncons doCons . ConstR

--- a/Data/Row/Records.hs
+++ b/Data/Row/Records.hs
@@ -80,7 +80,7 @@ module Data.Row.Records
   -- ** Coerce
   , coerceRec
   -- ** UNSAFE operations
-  , unsafeRemove, unsafeInjectFront
+  , lazyRemove, unsafeInjectFront
   )
 where
 
@@ -89,7 +89,7 @@ import Prelude hiding (map, sequence, zip)
 import Control.DeepSeq (NFData(..), deepseq)
 
 import           Data.Coerce
-import           Data.Constraint              (Dict(..), (\\))
+import           Data.Constraint              ((\\))
 import           Data.Dynamic
 import           Data.Functor.Compose
 import           Data.Functor.Const
@@ -152,7 +152,7 @@ instance (Forall r Bounded, AllUniqueLabels r) => Bounded (Rec r) where
 instance Forall r NFData => NFData (Rec r) where
   rnf r = getConst $ metamorph @_ @r @NFData @(,) @Rec @(Const ()) @Identity Proxy empty doUncons doCons r
     where empty = const $ Const ()
-          doUncons l r = (Identity $ r .! l, unsafeRemove l r)
+          doUncons l r = (Identity $ r .! l, lazyRemove l r)
           doCons _ (x, r) = deepseq x $ deepseq r $ Const ()
 
 -- | The empty record
@@ -228,8 +228,10 @@ OR m .- (toKey -> a) = OR $ M.delete a m
 
 -- | Record disjoint union (commutative)
 infixl 6 .+
-(.+) :: Rec l -> Rec r -> Rec (l .+ r)
-OR l .+ OR r = OR $ M.unionWith (error "Impossible") l r
+(.+) :: forall l r. FreeForall l => Rec l -> Rec r -> Rec (l .+ r)
+OR l .+ OR r = OR $ M.unionWithKey choose l r
+  where
+    choose k lv rv = if k `elem` labels' @l @Text then lv else rv
 
 -- | Record overwrite.
 --
@@ -254,26 +256,29 @@ pattern l :+ r <- (split @l -> (l, r)) where
         (:+) l r = l .+ r
 
 -- | Split a record into two sub-records.
-split :: forall s r. (Forall s Unconstrained1, Subset s r)
+split :: forall s r. (Subset s r, FreeForall s)
          => Rec r -> (Rec s, Rec (r .\\ s))
 split (OR m) = (OR $ M.intersection m labelMap, OR $ M.difference m labelMap)
-  where labelMap = M.fromList $ L.zip (labels @s @Unconstrained1) (repeat ())
+  where
+    labelMap = M.fromList $ L.zip (labels' @s) (repeat ())
 
 -- | Arbitrary record restriction.  Turn a record into a subset of itself.
-restrict :: forall r r'. (Forall r Unconstrained1, Subset r r') => Rec r' -> Rec r
+restrict :: forall r r'. (FreeForall r, Subset r r') => Rec r' -> Rec r
 restrict = fst . split
 
 -- | Removes a label from the record but does not remove the underlying value.
 --
--- This is faster than regular record removal ('.-') but should only be used when
--- either: the record will never be merged with another record again, or a new
--- value will soon be placed into the record at this label (as in, an 'update'
--- that is split over two commands).
+-- This is faster than regular record removal ('.-'), but it has two downsides:
 --
--- If the resulting record is then merged (with '.+') with another record that
--- contains a value at that label, an "impossible" error will occur.
-unsafeRemove :: KnownSymbol l => Label l -> Rec r -> Rec (r .- l)
-unsafeRemove _ (OR m) = OR m
+-- 1. It may incur a performance penalty during a future merge operation ('.+'), and
+--
+-- 2. It will keep the reference to the value alive, meaning that it will not get garbage collected.
+--
+-- Thus, it's great when one knows ahead of time that no future merges will happen
+-- and that the whole record will be GC'd soon, for instance, during the catamorphism
+-- function of 'metamorph'.
+lazyRemove :: KnownSymbol l => Label l -> Rec r -> Rec (r .- l)
+lazyRemove _ (OR m) = OR m
 
 
 {--------------------------------------------------------------------
@@ -290,19 +295,19 @@ erase f = fmap (snd @String) . eraseWithLabels @c f
 eraseWithLabels :: forall c ρ s b. (Forall ρ c, IsString s) => (forall a. c a => a -> b) -> Rec ρ -> [(s,b)]
 eraseWithLabels f = getConst . metamorph @_ @ρ @c @(,) @Rec @(Const [(s,b)]) @Identity Proxy doNil doUncons doCons
   where doNil _ = Const []
-        doUncons l r = (Identity $ r .! l, unsafeRemove l r)
+        doUncons l r = (Identity $ r .! l, lazyRemove l r)
         doCons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ)
-               => Label ℓ -> (Identity τ, Const [(s,b)] ('R ρ)) -> Const [(s,b)] ('R (ℓ :-> τ ': ρ))
+               => Label ℓ -> (Identity τ, Const [(s,b)] ρ) -> Const [(s,b)] (Extend ℓ τ ρ)
         doCons l (Identity x, Const c) = Const $ (show' l, f x) : c
 
 -- | A fold over two row type structures at once
 eraseZip :: forall c ρ b. Forall ρ c => (forall a. c a => a -> a -> b) -> Rec ρ -> Rec ρ -> [b]
 eraseZip f x y = getConst $ metamorph @_ @ρ @c @(,) @(Product Rec Rec) @(Const [b]) @Pair' Proxy (const $ Const []) doUncons doCons (Pair x y)
   where doUncons l (Pair r1 r2) = (Pair' (a, b), Pair r1' r2')
-          where (a, r1') = (r1 .! l, unsafeRemove l r1)
-                (b, r2') = (r2 .! l, unsafeRemove l r2)
+          where (a, r1') = (r1 .! l, lazyRemove l r1)
+                (b, r2') = (r2 .! l, lazyRemove l r2)
         doCons :: forall ℓ τ ρ. c τ
-               => Label ℓ -> (Pair' τ, Const [b] ('R ρ)) -> Const [b] ('R (ℓ :-> τ ': ρ))
+               => Label ℓ -> (Pair' τ, Const [b] ρ) -> Const [b] (Extend ℓ τ ρ)
         doCons _ (unPair' -> x, Const c) = Const $ uncurry f x : c
 
 -- | Turns a record into a 'HashMap' from values representing the labels to
@@ -320,11 +325,11 @@ map :: forall c f r. Forall r c => (forall a. c a => a -> f a) -> Rec r -> Rec (
 map f = unRMap . metamorph @_ @r @c @(,) @Rec @(RMap f) @Identity Proxy doNil doUncons doCons
   where
     doNil _ = RMap empty
-    doUncons l r = (Identity $ r .! l, unsafeRemove l r)
-    doCons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ, FrontExtends ℓ τ ρ)
-           => Label ℓ -> (Identity τ, RMap f ('R ρ)) -> RMap f ('R (ℓ :-> τ ': ρ))
-    doCons l (Identity v, RMap r) = case mapExtendSwap @ℓ @τ @('R ρ) @f of
-      Dict -> RMap (extend l (f v) r)
+    doUncons l r = (Identity $ r .! l, lazyRemove l r)
+    doCons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ)
+           => Label ℓ -> (Identity τ, RMap f ρ) -> RMap f (Extend ℓ τ ρ)
+    doCons l (Identity v, RMap r) = RMap (extend l (f v) r)
+      \\ mapExtendSwap @ℓ @τ @ρ @f
 
 newtype RFMap (g :: k1 -> k2) (ϕ :: Row (k2 -> *)) (ρ :: Row k1) = RFMap { unRFMap :: Rec (Ap ϕ (Map g ρ)) }
 newtype RecAp (ϕ :: Row (k -> *)) (ρ :: Row k) = RecAp (Rec (Ap ϕ ρ))
@@ -332,20 +337,24 @@ newtype App (f :: k -> *) (a :: k) = App (f a)
 
 -- | A function to map over a Ap record given constraints.
 mapF :: forall k c g (ϕ :: Row (k -> *)) (ρ :: Row k). BiForall ϕ ρ c
-     => (forall f a. (c f a) => f a -> f (g a))
+     => (forall h a. (c h a) => h a -> h (g a))
      -> Rec (Ap ϕ ρ)
      -> Rec (Ap ϕ (Map g ρ))
 mapF f = unRFMap . biMetamorph @_ @_ @ϕ @ρ @c @(,) @RecAp @(RFMap g) @App Proxy doNil doUncons doCons . RecAp
   where
     doNil _ = RFMap empty
-    doUncons l (RecAp r) = (App $ r .! l, RecAp $ unsafeRemove l r)
-    doCons :: forall ℓ τ1 τ2 ρ1 ρ2. (KnownSymbol ℓ, c τ1 τ2, FrontExtends ℓ τ1 ρ1, FrontExtends ℓ τ2 ρ2)
-           => Label ℓ -> (App τ1 τ2, RFMap g ('R ρ1) ('R ρ2)) -> RFMap g ('R (ℓ :-> τ1 ': ρ1)) ('R (ℓ :-> τ2 ': ρ2))
-    doCons l (App v, RFMap r) = case (mapExtendSwap @ℓ @τ2 @('R ρ2) @g, apExtendSwap @_ @ℓ @(g τ2) @(Map g ('R ρ2)) @τ1 @('R ρ1)) of
-      (Dict, Dict) -> RFMap (extend l (f @τ1 @τ2 v) r)
+    doUncons :: forall ℓ f τ ϕ ρ. (KnownSymbol ℓ, c f τ, HasType ℓ f ϕ, HasType ℓ τ ρ)
+             => Label ℓ -> RecAp ϕ ρ -> (App f τ, RecAp (ϕ .- ℓ) (ρ .- ℓ))
+    doUncons l (RecAp r) = (App $ r .! l, RecAp $ lazyRemove l r)
+      \\ apHas @ϕ @ρ @ℓ @f @τ
+    doCons :: forall ℓ f τ ϕ ρ. (KnownSymbol ℓ, c f τ)
+           => Label ℓ -> (App f τ, RFMap g ϕ ρ) -> RFMap g (Extend ℓ f ϕ) (Extend ℓ τ ρ)
+    doCons l (App v, RFMap r) = RFMap (extend l (f @f @τ v) r)
+      \\ mapExtendSwap @ℓ @τ @ρ @g
+      \\ apExtendSwap @_ @ℓ @(g τ) @(Map g ρ) @f @ϕ
 
 -- | A function to map over a record given no constraint.
-map' :: forall f r. Forall r Unconstrained1 => (forall a. a -> f a) -> Rec r -> Rec (Map f r)
+map' :: forall f r. FreeForall r => (forall a. a -> f a) -> Rec r -> Rec (Map f r)
 map' = map @Unconstrained1
 
 -- | Lifts a natural transformation over a record.  In other words, it acts as a
@@ -356,14 +365,17 @@ transform :: forall c r (f :: * -> *) (g :: * -> *). Forall r c => (forall a. c 
 transform f = unRMap . metamorph @_ @r @c @(,) @(RMap f) @(RMap g) @f Proxy doNil doUncons doCons . RMap
   where
     doNil _ = RMap empty
-    doUncons l (RMap r) = (r .! l, RMap $ unsafeRemove l r)
-    doCons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ, FrontExtends ℓ τ ρ)
-           => Label ℓ -> (f τ, RMap g ('R ρ)) -> RMap g ('R (ℓ :-> τ ': ρ))
-    doCons l (v, RMap r) = case mapExtendSwap @ℓ @τ @('R ρ) @g of
-      Dict -> RMap (extend l (f v) r)
+    doUncons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ, HasType ℓ τ ρ)
+             => Label ℓ -> RMap f ρ -> (f τ, RMap f (ρ .- ℓ))
+    doUncons l (RMap r) = (r .! l, RMap $ lazyRemove l r)
+      \\ mapHas @f @ρ @ℓ @τ
+    doCons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ)
+           => Label ℓ -> (f τ, RMap g ρ) -> RMap g (Extend ℓ τ ρ)
+    doCons l (v, RMap r) = RMap (extend l (f v) r)
+      \\ mapExtendSwap @ℓ @τ @ρ @g
 
 -- | A version of 'transform' for when there is no constraint.
-transform' :: forall r (f :: * -> *) (g :: * -> *). Forall r Unconstrained1 => (forall a. f a -> g a) -> Rec (Map f r) -> Rec (Map g r)
+transform' :: forall r (f :: * -> *) (g :: * -> *). FreeForall r => (forall a. f a -> g a) -> Rec (Map f r) -> Rec (Map g r)
 transform' = transform @Unconstrained1 @r
 
 -- | A version of 'sequence' in which the constraint for 'Forall' can be chosen.
@@ -372,11 +384,14 @@ sequence' :: forall f r c. (Forall r c, Applicative f)
 sequence' = getCompose . metamorph @_ @r @c @(,) @(RMap f) @(Compose f Rec) @f Proxy doNil doUncons doCons . RMap
   where
     doNil _ = Compose (pure empty)
-    doUncons l (RMap r) = (r .! l, RMap $ unsafeRemove l r)
+    doUncons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ, HasType ℓ τ ρ)
+             => Label ℓ -> RMap f ρ -> (f τ, RMap f (ρ .- ℓ))
+    doUncons l (RMap r) = (r .! l, RMap $ lazyRemove l r)
+      \\ mapHas @f @ρ @ℓ @τ
     doCons l (fv, Compose fr) = Compose $ extend l <$> fv <*> fr
 
 -- | Applicative sequencing over a record.
-sequence :: forall f r. (Forall r Unconstrained1, Applicative f)
+sequence :: forall f r. (Applicative f, FreeForall r)
          => Rec (Map f r) -> f (Rec r)
 sequence = sequence' @_ @_ @Unconstrained1
 
@@ -395,15 +410,19 @@ compose' :: forall c (f :: * -> *) (g :: * -> *) (r :: Row *) . Forall r c
 compose' = unRMap . metamorph @_ @r @c @(,) @(RMap2 f g) @(RMap (Compose f g)) @(Compose f g) Proxy doNil doUncons doCons . RMap2
   where
     doNil _ = RMap empty
-    doUncons l (RMap2 r) = (Compose $ r .! l, RMap2 $ unsafeRemove l r)
+    doUncons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ, HasType ℓ τ ρ)
+             => Label ℓ -> RMap2 f g ρ -> (Compose f g τ, RMap2 f g (ρ .- ℓ))
+    doUncons l (RMap2 r) = (Compose $ r .! l, RMap2 $ lazyRemove l r)
+      \\ mapHas @f @(Map g ρ) @ℓ @(g τ)
+      \\ mapHas @g @ρ @ℓ @τ
     doCons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ, FrontExtends ℓ τ ρ)
-           => Label ℓ -> (Compose f g τ, RMap (Compose f g) ('R ρ)) -> RMap (Compose f g) ('R (ℓ :-> τ ': ρ))
-    doCons l (v, RMap r) = case mapExtendSwap @ℓ @τ @('R ρ) @(Compose f g) of
-      Dict -> RMap $ extend l v r
+           => Label ℓ -> (Compose f g τ, RMap (Compose f g) ρ) -> RMap (Compose f g) (Extend ℓ τ ρ)
+    doCons l (v, RMap r) = RMap $ extend l v r
+      \\ mapExtendSwap @ℓ @τ @ρ @(Compose f g)
 
 -- | Convert from a record where two functors have been mapped over the types to
 -- one where the composition of the two functors is mapped over the types.
-compose :: forall (f :: * -> *) (g :: * -> *) r . Forall r Unconstrained1
+compose :: forall (f :: * -> *) (g :: * -> *) r . FreeForall r
         => Rec (Map f (Map g r)) -> Rec (Map (Compose f g) r)
 compose = compose' @Unconstrained1 @f @g @r
 
@@ -413,16 +432,20 @@ uncompose' :: forall c (f :: * -> *) (g :: * -> *) r . Forall r c
 uncompose' = unRMap2 . metamorph @_ @r @c @(,) @(RMap (Compose f g)) @(RMap2 f g) @(Compose f g) Proxy doNil doUncons doCons . RMap
   where
     doNil _ = RMap2 empty
-    doUncons l (RMap r) = (r .! l, RMap $ unsafeRemove l r)
-    doCons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ, FrontExtends ℓ τ ρ)
-           => Label ℓ -> (Compose f g τ, RMap2 f g ('R ρ)) -> RMap2 f g ('R (ℓ :-> τ ': ρ))
-    doCons l (Compose v, RMap2 r) = case (mapExtendSwap @ℓ @τ @('R ρ) @g, mapExtendSwap @ℓ @(g τ) @(Map g ('R ρ)) @f) of
-      (Dict, Dict) -> RMap2 $ extend l v r
+    doUncons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ, HasType ℓ τ ρ)
+             => Label ℓ -> RMap (Compose f g) ρ -> (Compose f g τ, RMap (Compose f g) (ρ .- ℓ))
+    doUncons l (RMap r) = (r .! l, RMap $ lazyRemove l r)
+      \\ mapHas @(Compose f g) @ρ @ℓ @τ
+    doCons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ)
+           => Label ℓ -> (Compose f g τ, RMap2 f g ρ) -> RMap2 f g (Extend ℓ τ ρ)
+    doCons l (Compose v, RMap2 r) = RMap2 $ extend l v r
+      \\ mapExtendSwap @ℓ @(g τ) @(Map g ρ) @f
+      \\ mapExtendSwap @ℓ @τ @ρ @g
 
 -- | Convert from a record where the composition of two functors have been mapped
 -- over the types to one where the two functors are mapped individually one at a
 -- time over the types.
-uncompose :: forall (f :: * -> *) (g :: * -> *) r . Forall r Unconstrained1
+uncompose :: forall (f :: * -> *) (g :: * -> *) r . FreeForall r
           => Rec (Map (Compose f g) r) -> Rec (Map f (Map g r))
 uncompose = uncompose' @Unconstrained1 @f @g @r
 
@@ -436,11 +459,14 @@ uncompose = uncompose' @Unconstrained1 @f @g @r
 --
 -- > newtype ConstR a b = ConstR (Rec a)
 -- > newtype FlipConstR a b = FlipConstR { unFlipConstR :: Rec b }
+-- > coerceRec :: forall r1 r2. BiForall r1 r2 Coercible => Rec r1 -> Rec r2
 -- > coerceRec = unFlipConstR . biMetamorph @_ @_ @r1 @r2 @Coercible @(,) @ConstR @FlipConstR @Const Proxy doNil doUncons doCons . ConstR
 -- >   where
 -- >     doNil _ = FlipConstR empty
--- >     doUncons l (ConstR r) = (Const (r .! l), ConstR (unsafeRemove l r))
--- >     doCons l (Const v, FlipConstR r) = FlipConstR $ extend l (coerce v) r
+-- >     doUncons l (ConstR r) = (Const (r .! l), ConstR (lazyRemove l r))
+-- >     doCons :: forall ℓ τ1 τ2 ρ1 ρ2. (KnownSymbol ℓ, Coercible τ1 τ2)
+-- >            => Label ℓ -> (Const τ1 τ2, FlipConstR ρ1 ρ2) -> FlipConstR (Extend ℓ τ1 ρ1) (Extend ℓ τ2 ρ2)
+-- >     doCons l (Const v, FlipConstR r) = FlipConstR $ extend l (coerce @τ1 @τ2 v) r
 coerceRec :: forall r1 r2. BiForall r1 r2 Coercible => Rec r1 -> Rec r2
 coerceRec = unsafeCoerce
 
@@ -450,15 +476,15 @@ newtype RecPair  (ρ1 :: Row *) (ρ2 :: Row *) = RecPair  (Rec ρ1, Rec ρ2)
 newtype RZipPair (ρ1 :: Row *) (ρ2 :: Row *) = RZipPair { unRZipPair :: Rec (Zip ρ1 ρ2) }
 
 -- | Zips together two records that have the same set of labels.
-zip :: forall r1 r2. BiForall r1 r2 Unconstrained2 => Rec r1 -> Rec r2 -> Rec (Zip r1 r2)
+zip :: forall r1 r2. FreeBiForall r1 r2 => Rec r1 -> Rec r2 -> Rec (Zip r1 r2)
 zip r1 r2 = unRZipPair $ biMetamorph @_ @_ @r1 @r2 @Unconstrained2 @(,) @RecPair @RZipPair @(,) Proxy doNil doUncons doCons $ RecPair (r1, r2)
   where
     doNil _ = RZipPair empty
-    doUncons l (RecPair (r1, r2)) = ((r1 .! l, r2 .! l), RecPair (unsafeRemove l r1, unsafeRemove l r2))
-    doCons :: forall ℓ τ1 τ2 ρ1 ρ2. (KnownSymbol ℓ, FrontExtends ℓ τ1 ρ1, FrontExtends ℓ τ2 ρ2)
-           => Label ℓ -> ((τ1, τ2), RZipPair ('R ρ1) ('R ρ2)) -> RZipPair ('R (ℓ :-> τ1 ': ρ1)) ('R (ℓ :-> τ2 ': ρ2))
-    doCons l ((v1, v2), RZipPair r) = case zipExtendSwap @ℓ @τ1 @('R ρ1) @τ2 @('R ρ2) of
-      Dict -> RZipPair $ extend l (v1, v2) r
+    doUncons l (RecPair (r1, r2)) = ((r1 .! l, r2 .! l), RecPair (lazyRemove l r1, lazyRemove l r2))
+    doCons :: forall ℓ τ1 τ2 ρ1 ρ2. (KnownSymbol ℓ)
+           => Label ℓ -> ((τ1, τ2), RZipPair ρ1 ρ2) -> RZipPair (Extend ℓ τ1 ρ1) (Extend ℓ τ2 ρ2)
+    doCons l ((v1, v2), RZipPair r) = RZipPair $ extend l (v1, v2) r
+      \\ zipExtendSwap @ℓ @τ1 @ρ1 @τ2 @ρ2
 
 -- | A helper function for unsafely adding an element to the front of a record.
 -- This can cause the resulting record to be malformed, for instance, if the record
@@ -495,15 +521,15 @@ fromLabelsA mk = getCompose $ metamorph @_ @ρ @c @FlipConst @(Const ()) @(Compo
   where doNil _ = Compose $ pure empty
         doUncons _ _ = FlipConst $ Const ()
         doCons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ, FrontExtends ℓ τ ρ)
-               => Label ℓ -> FlipConst (Proxy τ) (Compose f Rec ('R ρ)) -> Compose f Rec ('R (ℓ :-> τ ': ρ))
+               => Label ℓ -> FlipConst (Proxy τ) (Compose f Rec ρ) -> Compose f Rec (Extend ℓ τ ρ)
         doCons l (FlipConst (Compose r)) = Compose $ extend l <$> mk @ℓ @τ l <*> r
 
--- | Initialize a record that is produced by a `Map`.
+-- -- | Initialize a record that is produced by a `Map`.
 fromLabelsMapA :: forall c f g ρ. (Applicative f, Forall ρ c, AllUniqueLabels ρ)
                => (forall l a. (KnownSymbol l, c a) => Label l -> f (g a)) -> f (Rec (Map g ρ))
 fromLabelsMapA f = fromLabelsA @(IsA c g) @f @(Map g ρ) inner
                 \\ mapForall @g @c @ρ
-                \\ uniqueMap @g @ρ
+                \\ uniqueMap @ρ @g
    where inner :: forall l a. (KnownSymbol l, IsA c g a) => Label l -> f a
          inner l = case as @c @g @a of As -> f l
 
@@ -564,13 +590,13 @@ instance KnownSymbol name => GenericRec (R '[name :-> t]) where
   toRec (G.M1 (G.K1 a)) = (Label @name) :== a
 
 instance
-    ( GenericRec (R (name' :-> t' ': r'))
-    , KnownSymbol name, Extend name t ('R (name' :-> t' ': r')) ≈ 'R (name :-> t ': (name' :-> t' ': r'))
+    ( r ~ (name' :-> t' ': r'), GenericRec (R r)
+    , KnownSymbol name, Extend name t ('R r) ≈ 'R (name :-> t ': r)
     ) => GenericRec (R (name :-> t ': (name' :-> t' ': r'))) where
-  type RepRec (R (name :-> t ': (name' :-> t' ': r')))   = (G.S1
+  type RepRec (R (name :-> t ': (name' :-> t' ': r'))) = (G.S1
     ('G.MetaSel ('Just name) 'G.NoSourceUnpackedness 'G.NoSourceStrictness 'G.DecidedLazy)
     (G.Rec0 t)) G.:*: RepRec (R (name' :-> t' ': r'))
-  fromRec r = G.M1 (G.K1 (r .! Label @name)) G.:*: fromRec (unsafeRemove @name Label r)
+  fromRec r = G.M1 (G.K1 (r .! Label @name)) G.:*: fromRec (lazyRemove @name Label r)
   toRec (G.M1 (G.K1 a) G.:*: r) = extend @_ @name @('R (name' :-> t' ': r')) Label a (toRec r)
 
 {--------------------------------------------------------------------
@@ -628,7 +654,7 @@ instance FromNativeG G.U1 where
 instance KnownSymbol name => FromNativeG (G.S1 ('G.MetaSel ('Just name) p s l) (G.Rec0 t)) where
   fromNative' (G.M1 (G.K1 x)) =  (Label @name) .== x
 
-instance (FromNativeG l, FromNativeG r) => FromNativeG (l G.:*: r) where
+instance (FromNativeG l, FromNativeG r, FreeForall (NativeRowG l)) => FromNativeG (l G.:*: r) where
   fromNative' (x G.:*: y) = fromNative' @l x .+ fromNative' @r y
 
 type FromNative t = (G.Generic t, FromNativeG (G.Rep t))

--- a/Data/Row/Switch.hs
+++ b/Data/Row/Switch.hs
@@ -18,36 +18,47 @@
 
 
 module Data.Row.Switch
-  (
-    Switch(..)
+  ( switch
+  , caseon
   )
 where
+
+import Control.Arrow ((+++))
+import Data.Proxy
 
 import Data.Row.Internal
 import Data.Row.Records
 import Data.Row.Variants
 
+-- | A simple class that we use to provide a constraint for function application.
+class AppliesTo r f x | r x -> f, f r -> x where
+  applyTo :: f -> x -> r
+instance AppliesTo r (x -> r) x where
+  applyTo = ($)
 
+-- | A pair of a record and a variant.
+data SwitchData r v = SwitchData (Rec r) (Var v)
+
+-- | Like 'Const' but for two ignored type arguments.
+newtype Const2 x y z = Const2 { getConst2 :: x }
 
 -- | A 'Var' and a 'Rec' can combine if their rows line up properly.
-class Switch (v :: Row *) (r :: Row *) x | v x -> r, r x -> v where
-  {-# MINIMAL switch | caseon #-}
-  -- | Given a Variant and a Record of functions from each possible value
-  -- of the variant to a single output type, apply the correct
-  -- function to the value in the variant.
-  switch :: Var v -> Rec r -> x
-  switch = flip caseon
-  -- | The same as @switch@ but with the argument order reversed
-  caseon :: Rec r -> Var v -> x
-  caseon = flip switch
+-- Given a Variant along with a Record of functions from each possible value
+-- of the variant to a single output type, apply the correct
+-- function to the value in the variant.
+switch :: forall v r x. BiForall r v (AppliesTo x) => Var v -> Rec r -> x
+switch v r = getConst2 $ biMetamorph @_ @_ @r @v @(AppliesTo x) @Either @SwitchData @(Const2 x) @(Const2 x)
+  Proxy doNil doUncons doCons $ SwitchData r v
+  where
+    doNil (SwitchData _ v) = impossible v
+    doUncons :: forall ℓ f τ ϕ ρ. (KnownSymbol ℓ, AppliesTo x f τ, HasType ℓ f ϕ, HasType ℓ τ ρ)
+             => Label ℓ -> SwitchData ϕ ρ -> Either (Const2 x f τ) (SwitchData (ϕ .- ℓ) (ρ .- ℓ))
+    doUncons l (SwitchData r v) = (Const2 . applyTo (r .! l)) +++ (SwitchData $ lazyRemove l r) $ trial v l
+    -- doCons :: forall ℓ f τ ϕ ρ. (KnownSymbol ℓ, AppliesTo x f τ)
+    --        => Label ℓ -> Either (Const2 x f τ) (Const2 x ϕ ρ) -> Const2 x (Extend ℓ f ϕ) (Extend ℓ τ ρ)
+    doCons _ (Left  (Const2 x)) = Const2 x
+    doCons _ (Right (Const2 x)) = Const2 x
 
-
-instance Switch (R '[]) (R '[]) x where
-  switch = const . impossible
-
-instance (KnownSymbol l, Switch (R v) (R r) b)
-      => Switch (R (l :-> a ': v)) (R (l :-> (a -> b) ': r)) b where
-  switch v r = case trial v l of
-    Left x  -> (r .! l) x
-    Right v -> switch v (lazyRemove l r)
-    where l = Label @l
+-- | The same as 'switch' but with the argument order reversed
+caseon :: forall v r x. BiForall r v (AppliesTo x) => Rec r -> Var v -> x
+caseon = flip switch

--- a/Data/Row/Switch.hs
+++ b/Data/Row/Switch.hs
@@ -49,5 +49,5 @@ instance (KnownSymbol l, Switch (R v) (R r) b)
       => Switch (R (l :-> a ': v)) (R (l :-> (a -> b) ': r)) b where
   switch v r = case trial v l of
     Left x  -> (r .! l) x
-    Right v -> switch v (unsafeRemove l r)
+    Right v -> switch v (lazyRemove l r)
     where l = Label @l

--- a/Data/Row/Switch.hs
+++ b/Data/Row/Switch.hs
@@ -1,3 +1,11 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 -----------------------------------------------------------------------------
 -- |

--- a/Data/Row/Variants.hs
+++ b/Data/Row/Variants.hs
@@ -71,7 +71,6 @@ import Control.Arrow       ((+++), left, right)
 import Control.DeepSeq     (NFData(..), deepseq)
 
 import Data.Coerce
-import Data.Constraint                ((\\))
 import Data.Functor.Compose
 import Data.Functor.Identity
 import Data.Functor.Product
@@ -87,6 +86,7 @@ import           GHC.TypeLits
 
 import Unsafe.Coerce
 
+import Data.Row.Dictionaries
 import Data.Row.Internal
 
 {--------------------------------------------------------------------

--- a/Data/Row/Variants.hs
+++ b/Data/Row/Variants.hs
@@ -270,7 +270,7 @@ map f = unVMap . metamorph @_ @r @c @Either @Var @(VMap f) @Identity Proxy doNil
     doCons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ, FrontExtends ℓ τ ρ)
            => Label ℓ -> Either (Identity τ) (VMap f ('R ρ)) -> VMap f ('R (ℓ :-> τ ': ρ))
     doCons l (Left (Identity x)) = VMap $ unsafeMakeVar l $ f x
-    doCons l (Right (VMap v)) = case mapPreservesLabels @ℓ @τ @('R ρ) @f of
+    doCons l (Right (VMap v)) = case mapExtendSwap @ℓ @τ @('R ρ) @f of
       Dict -> VMap $ extend @(f τ) l v
 
 -- | A function to map over a variant given no constraint.
@@ -289,7 +289,7 @@ transform f = unVMap . metamorph @_ @r @c @Either @(VMap f) @(VMap g) @f Proxy d
     doCons :: forall ℓ τ ρ. (KnownSymbol ℓ, c τ, FrontExtends ℓ τ ρ)
            => Label ℓ -> Either (f τ) (VMap g ('R ρ)) -> VMap g ('R (ℓ :-> τ ': ρ))
     doCons l (Left x) = VMap $ unsafeMakeVar l $ f x
-    doCons l (Right (VMap v)) = case mapPreservesLabels @ℓ @τ @('R ρ) @g of
+    doCons l (Right (VMap v)) = case mapExtendSwap @ℓ @τ @('R ρ) @g of
       Dict -> VMap $ extend @(g τ) l v
 
 -- | A form of @transformC@ that doesn't have a constraint on @a@
@@ -326,7 +326,7 @@ compose = unVMap . metamorph @_ @r @Unconstrained1 @Either @(VMap2 f g) @(VMap (
     doCons :: forall ℓ τ ρ. (KnownSymbol ℓ, FrontExtends ℓ τ ρ)
            => Label ℓ -> Either (Compose f g τ) (VMap (Compose f g) ('R ρ)) -> VMap (Compose f g) ('R (ℓ :-> τ ': ρ))
     doCons l (Left x) = VMap $ unsafeMakeVar l x
-    doCons l (Right (VMap v)) = case mapPreservesLabels @ℓ @τ @('R ρ) @(Compose f g) of
+    doCons l (Right (VMap v)) = case mapExtendSwap @ℓ @τ @('R ρ) @(Compose f g) of
       Dict -> VMap $ extend @(Compose f g τ) l v
 
 -- | Convert from a variant where the composition of two functors have been mapped
@@ -340,7 +340,7 @@ uncompose = unVMap2 . metamorph @_ @r @Unconstrained1 @Either @(VMap (Compose f 
     doCons :: forall ℓ τ ρ. (KnownSymbol ℓ, FrontExtends ℓ τ ρ)
            => Label ℓ -> Either (Compose f g τ) (VMap2 f g ('R ρ)) -> VMap2 f g ('R (ℓ :-> τ ': ρ))
     doCons l (Left (Compose x)) = VMap2 $ unsafeMakeVar l x
-    doCons l (Right (VMap2 v)) = case (mapPreservesLabels @ℓ @τ @('R ρ) @g, mapPreservesLabels @ℓ @(g τ) @(Map g ('R ρ)) @f) of
+    doCons l (Right (VMap2 v)) = case (mapExtendSwap @ℓ @τ @('R ρ) @g, mapExtendSwap @ℓ @(g τ) @(Map g ('R ρ)) @f) of
       (Dict, Dict) -> VMap2 $ extend @(f (g τ)) l v
 
 

--- a/Data/Row/Variants.hs
+++ b/Data/Row/Variants.hs
@@ -1,3 +1,20 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE UndecidableInstances #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Row.Variants
@@ -318,6 +335,7 @@ uncompose = unVMap2 . metamorph' @_ @r @Unconstrained1 @(VMap (Compose f g)) @(V
 --
 -- Internally, this is implemented just with `unsafeCoerce`, but we provide the
 -- following implementation as a proof:
+--
 -- > newtype ConstR a b = ConstR { unConstR :: Var a }
 -- > newtype FlipConstR a b = FlipConstR { unFlipConstR :: Var b }
 -- > coerceVar = unFlipConstR . biMetamorph' @_ @_ @r1 @r2 @Coercible @ConstR @FlipConstR @Const Proxy doNil doUncons doCons . ConstR

--- a/Data/Row/Variants.hs
+++ b/Data/Row/Variants.hs
@@ -61,8 +61,6 @@ module Data.Row.Variants
   , labels
   -- ** Coerce
   , coerceVar
-  -- ** UNSAFE operations
-  , unsafeMakeVar, unsafeInjectFront
   )
 where
 
@@ -390,22 +388,6 @@ uncompose = unVMap2 . metamorph @_ @r @Unconstrained1 @Either @(VMap (Compose f 
 -- >     doCons l (Right (FlipConstR v)) = FlipConstR $ extend @τ2 l v
 coerceVar :: forall r1 r2. BiForall r1 r2 Coercible => Var r1 -> Var r2
 coerceVar = unsafeCoerce
-
-{--------------------------------------------------------------------
-  Unsafe functions
---------------------------------------------------------------------}
-
--- | An unsafe way to make a Variant.  This function does not guarantee that
--- the labels are all unique.
-unsafeMakeVar :: forall r l. KnownSymbol l => Label l -> r .! l -> Var r
-unsafeMakeVar (toKey -> l) = OneOf l . HideType
-
--- | A helper function for unsafely adding an element to the front of a variant.
--- This can cause the type of the resulting variant to be malformed, for instance,
--- if the variant already contains labels that are lexicographically before the
--- given label.
-unsafeInjectFront :: forall l a r. KnownSymbol l => Var (R r) -> Var (R (l :-> a ': r))
-unsafeInjectFront = unsafeCoerce
 
 {--------------------------------------------------------------------
   Variant initialization

--- a/Data/Row/Variants.hs
+++ b/Data/Row/Variants.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/examples/Examples.lhs
+++ b/examples/Examples.lhs
@@ -1,3 +1,4 @@
+> {-# LANGUAGE AllowAmbiguousTypes #-}
 > {-# LANGUAGE DataKinds #-}
 > {-# LANGUAGE DeriveGeneric #-}
 > {-# LANGUAGE FlexibleContexts #-}

--- a/examples/Examples.lhs
+++ b/examples/Examples.lhs
@@ -1,6 +1,11 @@
-> {-# LANGUAGE OverloadedLabels #-}
+> {-# LANGUAGE DataKinds #-}
 > {-# LANGUAGE DeriveGeneric #-}
+> {-# LANGUAGE FlexibleContexts #-}
+> {-# LANGUAGE OverloadedLabels #-}
 > {-# LANGUAGE PartialTypeSignatures #-}
+> {-# LANGUAGE ScopedTypeVariables #-}
+> {-# LANGUAGE TypeOperators #-}
+> {-# LANGUAGE ViewPatterns #-}
 > module Examples where
 >
 > import Data.Row

--- a/examples/RowCSV.hs
+++ b/examples/RowCSV.hs
@@ -1,8 +1,12 @@
-{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
 module RowCSV where
 
 import GHC.Generics (Generic)

--- a/examples/RowCSV.md
+++ b/examples/RowCSV.md
@@ -40,12 +40,15 @@ than Oleg's version.
 <summary>Extensions and imports for this Literate Haskell file</summary>
 
 ```haskell
-
-{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
 module RowCSV where
 
 import GHC.Generics (Generic)

--- a/examples/TypeSurgery.lhs
+++ b/examples/TypeSurgery.lhs
@@ -50,10 +50,14 @@ to demonstrate how to use row-types to do type surgery.
 
 \iffalse
 \begin{code}
-{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
 module TypeSurgery where
 
 import Data.Row

--- a/examples/TypeSurgery.md
+++ b/examples/TypeSurgery.md
@@ -28,9 +28,14 @@ to demonstrate how to use row-types to do type surgery.
 <summary>Extensions and imports for this Literate Haskell file</summary>
 
 ```haskell
-{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
 module TypeSurgery where
 
 import qualified Data.Row.Records as Rec

--- a/examples/TypedErrors.lhs
+++ b/examples/TypedErrors.lhs
@@ -45,7 +45,11 @@ As this is a Literate Haskell file, let's get the imports and pragmas out of the
 way first...
 
 \begin{code}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
 module TypedErrors where
 
 import Data.Row

--- a/examples/TypedErrors.md
+++ b/examples/TypedErrors.md
@@ -21,7 +21,11 @@ As this is a Literate Haskell file, let's get the imports and pragmas out of the
 way first...
 
 ```haskell
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
 module TypedErrors where
 
 import Data.Row

--- a/row-types.cabal
+++ b/row-types.cabal
@@ -39,6 +39,7 @@ Library
   Exposed-modules:
       Data.Row
     , Data.Row.Internal
+    , Data.Row.Dictionaries
     , Data.Row.Records
     , Data.Row.Variants
     , Data.Row.Switch

--- a/row-types.cabal
+++ b/row-types.cabal
@@ -44,6 +44,12 @@ Library
     , Data.Row.Switch
   ghc-options: -W
   default-language: Haskell2010
+  default-extensions:
+      DataKinds
+    , ExplicitForAll
+    , OverloadedLabels
+    , TypeApplications
+    , TypeOperators
 
 benchmark perf
   type: exitcode-stdio-1.0

--- a/row-types.cabal
+++ b/row-types.cabal
@@ -4,8 +4,10 @@ License:             MIT
 License-file:        LICENSE
 Author:              Daniel Winograd-Cort, Matthew Farkas-Dyck
 Maintainer:          dwincort@gmail.com
+homepage:            https://github.com/target/row-types
 Build-Type:          Simple
-Cabal-Version:       >=1.8
+Cabal-Version:       >=1.10
+Tested-With:         GHC == 8.4, GHC == 8.6, GHC == 8.8
 Category:            Data, Data Structures
 Synopsis:	           Open Records and Variants
 Description:
@@ -25,44 +27,23 @@ extra-source-files:
   NOTICE
 
 Library
-  Build-Depends: base >= 2 && < 5,
-                 constraints,
-                 deepseq >= 1.4,
-                 hashable >= 1.2,
-                 unordered-containers >= 0.2,
-                 generic-lens >= 1.0.0.0,
-                 profunctors >= 5.0,
-                 text
-  Exposed-modules: Data.Row
-                 , Data.Row.Internal
-                 , Data.Row.Records
-                 , Data.Row.Variants
-                 , Data.Row.Switch
+  Build-Depends:
+    base >= 2 && < 5,
+    constraints,
+    deepseq >= 1.4,
+    hashable >= 1.2,
+    unordered-containers >= 0.2,
+    generic-lens >= 1.0.0.0,
+    profunctors >= 5.0,
+    text
+  Exposed-modules:
+      Data.Row
+    , Data.Row.Internal
+    , Data.Row.Records
+    , Data.Row.Variants
+    , Data.Row.Switch
   ghc-options: -W
-  Extensions: AllowAmbiguousTypes,
-              ConstraintKinds,
-              DataKinds,
-              EmptyCase,
-              EmptyDataDecls,
-              FlexibleContexts,
-              FlexibleInstances,
-              GADTs,
-              InstanceSigs,
-              KindSignatures,
-              LambdaCase,
-              MultiParamTypeClasses,
-              OverloadedLabels,
-              PatternGuards,
-              PatternSynonyms,
-              PolyKinds,
-              RankNTypes,
-              ScopedTypeVariables,
-              TypeApplications,
-              TypeFamilies,
-              TypeOperators,
-              TupleSections,
-              ViewPatterns,
-              UndecidableInstances
+  default-language: Haskell2010
 
 benchmark perf
   type: exitcode-stdio-1.0
@@ -74,7 +55,8 @@ benchmark perf
                , row-types
                , deepseq >= 1.4
                , criterion >= 1.1
-  Extensions: AllowAmbiguousTypes,
+  default-language: Haskell2010
+  default-extensions: AllowAmbiguousTypes,
               DataKinds,
               OverloadedLabels,
               RankNTypes,
@@ -92,7 +74,8 @@ test-suite test
   build-depends: base >= 2 && < 6
                , generic-lens >= 1.1.0.0
                , row-types
-  Extensions: AllowAmbiguousTypes,
+  default-language: Haskell2010
+  default-extensions: AllowAmbiguousTypes,
               DataKinds,
               FlexibleContexts,
               OverloadedLabels,

--- a/row-types.cabal
+++ b/row-types.cabal
@@ -48,6 +48,7 @@ Library
   default-extensions:
       DataKinds
     , ExplicitForAll
+    , GADTs
     , OverloadedLabels
     , TypeApplications
     , TypeOperators


### PR DESCRIPTION
## Overview
This is a pretty large update to the internals of row-types, specifically with respect to `metamorph`.  Regular users probably won't be affected, but those calling `metamorph` themselves will certainly see breakages.

## Details
I rewrote `Forall`, folding the behavior of `metamorph'` into a more abstract version of `metamorph`.  I also adjusted the types so that you no longer need to use `unsafe` functions when calling `metamorph`.  Instead, there is now a module `Data.Row.Dictionaries` that exports a number of `Dict`s and entailments designed to help the type checker, and between the updated types and the dicts, you can get away with calling `metamorph` with normal variant and record operators.

While doing this, I realized that the function `unsafeRemove` for records didn't actually need to be unsafe — really, it was just lazy.  I updated `.+` to account for this laziness and then renamed the function to `lazyRemove` with haddock that explains how/why one would want to use it.  I removed the other unsafe record and variant functions.

## Dealing with changes
For regular users of row-types, the changes in this PR shouldn't be breaking.  That said, if you use `metamorph` directly, it's very likely that your code won't compile anymore.  To fix your code, you'll need to follow three basic steps:
1. Note the new type parameter `p` for `metamorph`.  For metamorphing records, typically this should be `(,)`.  For metamorphing variants, note that `metamorph'` is gone -- instead use `metamorph` with `p` as `Either`.
2. If you have type signatures for the individual functions being supplied to `metamorph`, they will need to be updated.  Check the new signatures in the class definition.  You shouldn't need the `FrontExtends` constraint so you can leave that out, and the `AllUniqueLabels` constraint is usually only necessary for variants.
3. If you're still getting type errors, they'll typically be GHC complaining that it can't deduce some necessary constraint.  It may be something "obvious", like that `Map f (Extend l t r) ~ Extend l (f t) (Map f r)` (i.e., that map and extend more or less commute).  If so, import `Data.Row.Dictionaries` to grab the relevant dictionary.  Then add, e.g., `\\ mapExtendSwap @l @t @r @f` to the offending expression.
