### PR TITLE
better error messages and fixed examples text

### DIFF
--- a/examples/Examples.lhs
+++ b/examples/Examples.lhs
@@ -159,8 +159,7 @@ We can see it work in practice:
 λ> distance (move (named "2D" origin3D) 5 12)
 13.0
 
-Note that if we were using row-types-lens and the lens library, we could write
-move as:
+Or, with lenses, we could write move as:
 
 > moveLensy p dx dy = p & #x %~ (+ dx) & #y %~ (+ dy)
 


### PR DESCRIPTION
I really wish I could customize how GHC prints out row-types in general, but with this adjustment, at least they pretty-print in my custom error messages.

Also, I fixed some old text that needed to be updated in Examples.lhs.