### PR TITLE
Flip some arguments

### DIFF
--- a/Data/Row.hs
+++ b/Data/Row.hs
@@ -31,7 +31,7 @@ module Data.Row
   , Var, Rec, Row, Empty, type (≈)
   , HasType, Lacks, type (.\), type (.+)
   , type (.\/), type (.\\), type (.//)
-  , BiForall, Forall
+  , BiForall, Forall, FreeForall, FreeBiForall
   , switch, caseon
   -- * Record Construction
   , empty
@@ -54,6 +54,7 @@ module Data.Row
   )
 where
 
+import Data.Row.Dictionaries
 import Data.Row.Variants
 import Data.Row.Records
 import Data.Row.Switch

--- a/Data/Row/Switch.hs
+++ b/Data/Row/Switch.hs
@@ -24,9 +24,9 @@ module Data.Row.Switch
   )
 where
 
-import Control.Arrow ((+++))
 import Data.Proxy
 
+import Data.Bifunctor (Bifunctor(..))
 import Data.Row.Internal
 import Data.Row.Records
 import Data.Row.Variants
@@ -53,8 +53,8 @@ switch v r = getConst2 $ biMetamorph @_ @_ @r @v @(AppliesTo x) @Either @SwitchD
   where
     doNil (SwitchData _ v) = impossible v
     doUncons :: forall ℓ f τ ϕ ρ. (KnownSymbol ℓ, AppliesTo x f τ, HasType ℓ f ϕ, HasType ℓ τ ρ)
-             => Label ℓ -> SwitchData ϕ ρ -> Either (Const2 x f τ) (SwitchData (ϕ .- ℓ) (ρ .- ℓ))
-    doUncons l (SwitchData r v) = (Const2 . applyTo (r .! l)) +++ (SwitchData $ lazyRemove l r) $ trial v l
+             => Label ℓ -> SwitchData ϕ ρ -> Either (SwitchData (ϕ .- ℓ) (ρ .- ℓ)) (Const2 x f τ)
+    doUncons l (SwitchData r v) = bimap (SwitchData $ lazyRemove l r) (Const2 . applyTo (r .! l)) $ trial v l
     -- doCons :: forall ℓ f τ ϕ ρ. (KnownSymbol ℓ, AppliesTo x f τ)
     --        => Label ℓ -> Either (Const2 x f τ) (Const2 x ϕ ρ) -> Const2 x (Extend ℓ f ϕ) (Extend ℓ τ ρ)
     doCons _ (Left  (Const2 x)) = Const2 x

--- a/examples/Examples.lhs
+++ b/examples/Examples.lhs
@@ -309,16 +309,16 @@ What can you do with a variant?  The only way to really use one is to get the va
 out, and to do that, you must trial it:
 
 λ> trial v #x
-Left 1
+Right 1
 λ> trial v #y
-Right {x=1}
+Left {x=1}
 λ> trial v' #x
-Right {y="Foo"}
+Left {y="Foo"}
 λ> trial v' #y
-Left "Foo"
+Right "Foo"
 
-If trialing at a label l succeeds, then it provides a Left value of the value at l.
-If not, it provides a Right value of the variant with this label removed---since the
+If trialing at a label l succeeds, then it provides a Right value of the value at l.
+If not, it provides a Left value of the variant with this label removed---since the
 trial failed, we now can be sure that the value is not from l.
 
 --------------------------------------------------------------------------------
@@ -414,18 +414,18 @@ of the type you want or a Variant of the leftovers.  Consider the examples:
 λ> :t multiTrial @("x" .== Double .+ "y" .== String) v
 multiTrial @("x" .== Double .+ "y" .== String) v
   :: Either
-       (Var ('R '["x" ':-> Double, "y" ':-> String]))
        (Var ('R '["x" ':-> Integer]))
+       (Var ('R '["x" ':-> Double, "y" ':-> String]))
 λ> multiTrial @("x" .== Double .+ "y" .== String) v
-Right {x=1}
+Left {x=1}
 
 λ> :t multiTrial @("x" .== Double .+ "y" .== String) v'
 multiTrial @("x" .== Double .+ "y" .== String) v'
   :: Either
-       (Var ('R '["x" ':-> Double, "y" ':-> String]))
        (Var ('R '["x" ':-> Integer]))
+       (Var ('R '["x" ':-> Double, "y" ':-> String]))
 λ> multiTrial @("x" .== Double .+ "y" .== String) v'
-Left {y="Foo"}
+Right {y="Foo"}
 
 Thus, multiTrial can be used not only to arbitrarily split apart a variant, but
 also to change unused label associations (in this case, we changed the variant


### PR DESCRIPTION
This is pretty expansive, but it comes down to a core idea: that `trial` should put its successful result in the `Right` instead of the `Left` (https://github.com/target/row-types/issues/54).  This has a bit of a rippling effect that made me change the order of arguments to the bifunctor in `metamorph`.  In total, this certainly breaks lots of internals as well as anyone who uses `trial`, `multiTrial`, or `split`.

I also added a few reasonable exports, including a few new record and variant functions that may be convenient.