### PR TITLE
Optional

### DIFF
--- a/Data/Row/Internal.hs
+++ b/Data/Row/Internal.hs
@@ -41,6 +41,7 @@ module Data.Row.Internal
   , Lacks, type (.\), HasType
   , Forall(..)
   , BiForall(..)
+  , Optional(..)
   , BiConstraint
   , Unconstrained
   , Unconstrained1
@@ -55,7 +56,6 @@ module Data.Row.Internal
   , show'
   , toKey
   , type (≈)
-  , Optional(..)
   )
 where
 
@@ -219,18 +219,6 @@ type (l :: Symbol) .== (a :: k) = Extend l a Empty
   Constrained record operations
 --------------------------------------------------------------------}
 
-type family TypeEq (a :: k) (b :: k) :: Symbol where
-  TypeEq a a = "True"
-  TypeEq a b = "False"
-
--- | This is a hack to get type equality without using 'Typeable'.  It relies on
--- the fact that the type family 'TypeEq' is closed, but it still may fail when
--- 'TypeEq' can't properly reduce (for instance, in the presence of some polymorphism).
-typeEq :: forall a b. KnownSymbol (TypeEq a b) => Maybe (a :~: b)
-typeEq = case sameSymbol (Proxy @(TypeEq a b)) (Proxy @"True") of
-  Just Refl -> Just $ UNSAFE.unsafeCoerce Refl
-  Nothing -> Nothing
-
 -- | 'Optional l a r' indicates that label 'l' _may_ point to a type 'a' in 'r'.
 -- The value 'optional' will be 'Just Dict' at runtime if it does and 'Nothing'
 -- otherwise.  This allows one to ask for optional features of a row-type.
@@ -240,12 +228,15 @@ class Optional (l :: Symbol) (a :: k) (r :: Row k) where
 instance Optional l a Empty where
   optional = Nothing
 
-instance (KnownSymbol l, KnownSymbol l', Optional l a ('R r), KnownSymbol (TypeEq a b)) => Optional l a ('R (l' :-> b ': r)) where
-  optional = case (cmpSymbol (Proxy @l') (Proxy @l), typeEq @a @b, optional @_ @l @a @('R r)) of
+instance ( KnownSymbol l, KnownSymbol l', Optional l a ('R r)
+         , Ifte (CmpSymbol l l' == 'EQ) (a ~ b) Unconstrained
+         , Ifte (l' <=.? l) (Get l r ~ Get l (l' :-> b ': r)) Unconstrained
+  ) => Optional l a ('R (l' :-> b ': r)) where
+  optional = case (cmpSymbol (Proxy @l') (Proxy @l), optional @_ @l @a @('R r)) of
     -- The labels are equal and the types at those labels are equal.
-    (Left Refl, Just Refl, _) -> Just Dict
+    (Left Refl, _) -> Just Dict
     -- The label we're looking for is deeper in the row
-    (Right (Left Refl), _, Just Dict) -> Just Dict \\ preserveGet @l @l' @b @r
+    (Right (Left Refl), Just Dict) -> Just Dict
     _ -> Nothing
 
 -- | Like 'sameSymbol', but if the symbols aren't equal, this additionally provides
@@ -257,21 +248,6 @@ cmpSymbol x y = case compare (symbolVal x) (symbolVal y) of
   LT -> Right (Left  (UNSAFE.unsafeCoerce Refl))
   GT -> Right (Right (UNSAFE.unsafeCoerce Refl))
 
--- | 'Get' is preserved through a row-type so long as the label isn't yet found.
-preserveGet :: forall l l' a r. ((l' <=.? l) ~ True) :- (Get l (l' :-> a ': r) ~ Get l r)
-preserveGet = Sub $ UNSAFE.unsafeCoerce $ Dict @((l' <=.? l) ~ True)
-
-
--- instance {-# OVERLAPPING  #-} Optional l a ('R (l :-> a ': r)) where
---   optional = Just Dict
---
--- instance {-# OVERLAPPABLE  #-} Optional l a ('R (l :-> b ': r)) where
---   optional = Nothing
---
--- instance {-# OVERLAPPABLE #-} (Optional l a ('R r), Get l ((l' :-> b) : r) ~ Get l r) => Optional l a ('R (l' :-> b ': r)) where
---   optional = case optional @_ @l @a @('R r) of
---     Nothing -> Nothing
---     Just Dict -> Just Dict
 
 
 -- | A dictionary of information that proves that extending a row-type @r@ with

--- a/Data/Row/Records.hs
+++ b/Data/Row/Records.hs
@@ -56,6 +56,8 @@ module Data.Row.Records
   , type (.+), (.+), Disjoint, pattern (:+)
   -- ** Overwrite
   , type (.//), (.//)
+  -- ** Optional
+  , upcastOptional
   -- * Native Conversion
   -- $native
   , fromNative, toNative, toNativeGeneral
@@ -247,6 +249,14 @@ OR l .+ OR r = OR $ M.unionWithKey choose l r
 -- This can be thought of as @r@ "overwriting" @r'@.
 (.//) :: Rec r -> Rec r' -> Rec (r .// r')
 OR l .// OR r = OR $ M.union l r
+
+-- | Turn an optional constraint on a record into a record with a 'Maybe' value
+-- at the optional label.
+upcastOptional :: forall l a r. (Optional l a r, KnownSymbol l) => Rec r -> Rec ((l .== Maybe a) .// r)
+upcastOptional r = case optional @_ @l @a @r of
+  Nothing -> (l .== Nothing @a) .// r
+  Just Dict -> (l .== Just (r .! l)) .// r
+  where l = Label @l
 
 -- | A pattern version of record union, for use in pattern matching.
 {-# COMPLETE (:+) #-}


### PR DESCRIPTION
This PR adds an `Optional` type class that allows one to have an optional element in the row-types.  It also adds a convenience function for records that allows one to turn an optional field into a field of an option.

Resolves https://github.com/target/row-types/issues/57.

## Design Notes
See the related issue for a more full accounting of the details of `Optional`.  In short, due to GHC's inability to perform type equality at the value level without requiring `Typeable` (which I really didn't want to add), an `Optional` constraint must additionally require that if the label exists in the row-type, it _must_ have the optional type.  In other words, a constraint like `Optional "x" Int r` will be satisfied by a row-type `r` that does not contain `"x"`, but will not type check with a row-type `r` that has an entry where `"x"` is `String`.

Also, I've introduced the function `cmpSymbol`, which [should be upstreamed if possible](https://gitlab.haskell.org/ghc/ghc/issues/18367).