### PR TITLE
Export AppliesTo from Data.Row.Switch

### DIFF
--- a/Data/Row/Switch.hs
+++ b/Data/Row/Switch.hs
@@ -18,7 +18,8 @@
 
 
 module Data.Row.Switch
-  ( switch
+  ( AppliesTo(..)
+  , switch
   , caseon
   )
 where


### PR DESCRIPTION
I've been updating `open-adt` with the changes in #63 for testing purposes before continuing with that pull request, but I appear to need `AppliesTo` exported so I can use it in constraints when using `switch`/`caseon`. This pull request adds `AppliesTo` to the exports of `Data.Row.Switch`.