### PR TITLE
Work around poor GHC performance on MinJoinR and ConstUnionR

### DIFF
--- a/row-types.cabal
+++ b/row-types.cabal
@@ -79,8 +79,9 @@ test-suite test
   type: exitcode-stdio-1.0
   main-is: Main.hs
   hs-source-dirs: tests, examples
-  ghc-options: -W
-  other-modules: Examples
+  ghc-options: -W +RTS -M1G -RTS
+  other-modules: Examples,
+                 UnionPerformance
   build-depends: base >= 2 && < 6
                , generic-lens >= 1.1.0.0
                , row-types

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -2,5 +2,6 @@
 module Main where
 
 import Examples ()
+import UnionPerformance ()
 
 main = putStrLn "Test passes if Examples.lhs type-checks."

--- a/tests/UnionPerformance.hs
+++ b/tests/UnionPerformance.hs
@@ -1,0 +1,19 @@
+
+-- The old implementation of MinJoinR and ConstUnionR (using Ifte) makes GHC blow up when there are
+-- nested unions with many overlapping keys. The test suite checks this file with 1GB max heap,
+-- which is plenty for the new implementation, but not nearly enough for the old.
+
+module UnionPerformance where
+
+import Data.Row
+
+type Key l  = l .== ()
+type Common = Key "a" .\/ Key "d" .\/ Key "f" .\/ Key "h" .\/ Key "k" .\/ Key "n" .\/ Key "q" .\/ Key "v"
+type Ext l  = Common .\/ Key l
+
+type MinJoin    = Ext "b" .\/ Ext "e" .\/ Ext "g" .\/ Ext "j" .\/ Ext "o" .\/ Ext "t" .\/ Ext "w"
+type ConstUnion = Ext "b" .// Ext "e" .// Ext "g" .// Ext "j" .// Ext "o" .// Ext "t" .// Ext "w"
+
+test :: Rec MinJoin -> Rec ConstUnion
+test = id
+


### PR DESCRIPTION
GHC uses exponential(?) amounts of memory on MinJoinR and ConstUnionR when there are nested calls with many overlapping keys. This can be worked around by specializing `Ifte` to the branches we need in the two cases.