### PR TITLE
Fix Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        cabal: ["3.2"]
+        cabal: ["latest"]
         ghc:
           - "8.6.5"
           - "8.8.3"
-          - "8.10.1"
+          # - "8.10.1"
+          - "latest"
         exclude:
           - os: macOS-latest
             ghc: 8.8.3
@@ -32,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1.1
+    - uses: actions/setup-haskell@v1
       id: setup-haskell-cabal
       name: Setup Haskell
       with:
@@ -63,14 +64,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        stack: ["2.3.1"]
-        ghc: ["8.8.3"]
+        stack: ["latest"]
+        ghc:
+          - "8.8.3"
+          - "latest"
 
     steps:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1
+    - uses: actions/setup-haskell@v1
       name: Setup Haskell Stack
       with:
         ghc-version: ${{ matrix.ghc }}


### PR DESCRIPTION
Due to some recent changes int GitHub Actions, we need to update to the latest version of [setup-haskell](https://github.com/actions/setup-haskell).

According to their site, setting it to `v1` should make it automatically pull the latest version, so we don't need to manually update in the future.