### PR TITLE
Work around poor GHC performance on Diff and Merge

### DIFF
--- a/row-types.cabal
+++ b/row-types.cabal
@@ -81,6 +81,8 @@ test-suite test
   hs-source-dirs: tests, examples
   ghc-options: -W +RTS -M1G -RTS
   other-modules: Examples,
+                 DiffPerformance,
+                 MergePerformance,
                  UnionPerformance
   build-depends: base >= 2 && < 6
                , generic-lens >= 1.1.0.0

--- a/tests/DiffPerformance.hs
+++ b/tests/DiffPerformance.hs
@@ -1,0 +1,15 @@
+module DiffPerformance where
+
+import Data.Row
+
+type Key l = l .== ()
+type Common = Key "z" .\/ Key "x" .\/ Key "y" .\/ Key "m" .\/ Key "n" .\/ Key "q" .\/ Key "v"
+type Ext l  = Common .\/ Key l
+
+type A = Ext "a" .\/ Ext "b" .\/ Ext "c" .\/ Ext "d" .\/ Ext "e" .\/ Ext "f" .\/ Ext "g" .\/ Ext "h" .\/ Ext "i"
+
+type AWithoutCommon = Key "a" .\/ Key "b" .\/ Key "c" .\/ Key "d" .\/ Key "e" .\/ Key "f" .\/ Key "g" .\/ Key "h" .\/ Key "i"
+
+test :: Rec (A .\\ Common) -> Rec AWithoutCommon
+test = id
+

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -2,6 +2,8 @@
 module Main where
 
 import Examples ()
+import DiffPerformance ()
+import MergePerformance ()
 import UnionPerformance ()
 
 main = putStrLn "Test passes if Examples.lhs type-checks."

--- a/tests/MergePerformance.hs
+++ b/tests/MergePerformance.hs
@@ -1,0 +1,13 @@
+module MergePerformance where
+
+import Data.Row
+
+type Key l = l .== ()
+type Common = Key "z" .\/ Key "x" .\/ Key "y" .\/ Key "m" .\/ Key "n" .\/ Key "q" .\/ Key "v"
+type Ext l  = Common .\/ Key l
+
+type A = Ext "a" .\/ Ext "b" .\/ Ext "c" .\/ Ext "d" .\/ Ext "e" .\/ Ext "f" .\/ Ext "g" .\/ Ext "h" .\/ Ext "i"
+
+test :: Rec (Common .+ A) -> Rec (Common .+ A)
+test = id
+


### PR DESCRIPTION
The problem is the same as in #71.

I also have tried to fix `Inject` and `LacksR` but haven't found tests cases with bad performance. 